### PR TITLE
Updated color vertices export to work with Blender 2.62.

### DIFF
--- a/Blender Export/objc_blend_2.57 (RC1)/io_export_objective_c_header.py
+++ b/Blender Export/objc_blend_2.57 (RC1)/io_export_objective_c_header.py
@@ -161,7 +161,7 @@ typedef vertexDataTextured* vertexDataTexturedPtr;\n\n\n')
 typedef struct vertexDataColored vertexDataColored;\n\
 typedef vertexDataColored* vertexDataColoredPtr;\n\n\n')
 		writeString(file, 'static const vertexDataColored %sVertexData[] = {\n' % basename)
-		color_layer = mesh.active_vertex_color
+		color_layer = mesh.vertex_colors.active
 		for face in mesh.faces:
 			if len(face.vertices) == 3:
 				faceC = color_layer.data[face.index]


### PR DESCRIPTION
Export of color vertices was not working in the latest Blender version (I haven't tried others).

This fix would probably go in another folder, but having a folder for every Blender revision may be hard... Perhaps just keep the latest version of the plugin compatible with the most recent Blender version. If someone wants to use an older version, just browsing through the commit changes will suffice, I guess. 
