### PR TITLE
Use glGetShaderInfoLog instead of glGetProgramInfoLog

### DIFF
--- a/Simple OpenGL ES 2.0 Example/Classes/GLProgram.m
+++ b/Simple OpenGL ES 2.0 Example/Classes/GLProgram.m
@@ -147,15 +147,15 @@ typedef void (*GLLogFunction) (GLuint program,
 - (NSString *)vertexShaderLog
 {
     return [self logForOpenGLObject:vertShader 
-                       infoCallback:(GLInfoFunction)&glGetProgramiv 
-                            logFunc:(GLLogFunction)&glGetProgramInfoLog];
+                       infoCallback:(GLInfoFunction)&glGetShaderiv 
+                            logFunc:(GLLogFunction)&glGetShaderInfoLog];
     
 }
 - (NSString *)fragmentShaderLog
 {
     return [self logForOpenGLObject:fragShader 
-                       infoCallback:(GLInfoFunction)&glGetProgramiv 
-                            logFunc:(GLLogFunction)&glGetProgramInfoLog];
+                       infoCallback:(GLInfoFunction)&glGetShaderiv 
+                            logFunc:(GLLogFunction)&glGetShaderInfoLog];
 }
 - (NSString *)programLog
 {


### PR DESCRIPTION
Hi Jeff,

Thanks for putting this stuff out there.

I encountered one small issue with GLProgram. 

It seems that in order to get compilation error messages I need to use glGetShaderInfoLog instead of glGetProgramInfoLog. Here's a teeny patch.

Cheers,
Jon
